### PR TITLE
Select code in code window onClick

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -310,7 +310,9 @@ class App extends React.Component {
                 id="codeview"
                 rows="25"
                 value={productsHtml}
-                readOnly />}
+                readOnly
+                onClick={(e) => e.target.select()} />
+              }
             {activeTab === 'preview'
               && <div
                 id="preview"


### PR DESCRIPTION
One-liner fix for selecting code automatically after clicking in the code window.