### PR TITLE
Spot it shop it dark mode

### DIFF
--- a/templates/botnavs.js
+++ b/templates/botnavs.js
@@ -20,7 +20,7 @@ export default function botnavs(section, locale) {
     <td align="center">
     ${locale === 'caEN' ?
       `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/ca/en/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; border-top: 3px solid black; padding-top: 10px;">`
-      : `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/?$deep_link=true[/@trackurl]"  target="_blank style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; border-top: 3px solid black; padding-top: 10px;">`}
+      : `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; border-top: 3px solid black; padding-top: 10px;">`}
         Spot it. Shop it.
       </a>
     </td>

--- a/templates/botnavs.js
+++ b/templates/botnavs.js
@@ -8,13 +8,13 @@ export default function botnavs(section, locale) {
       [#-- Dev Sandbox / 2021_New_Clients_Banners_Map --][#contentmap id='dda18b65-5406-489b-a7f3-30539cb5a198'/]
     </td>
   </tr>` : ``}
-  ${locale === 'caFR' ?
-  `<tr>
+  <tr>
     <td>
       <table width="662" height="3" border="0" bgcolor="black" cellspacing="0" cellpadding="0" align="center" style="margin-top:10px;"><td style="font-size:1px; line-height:1px;">&nbsp;</td></table>
     </td>
   </tr>
-  <tr>
+  ${locale === 'caFR' ?
+  `<tr>
     <td align="center" style="padding: 10px 0 10px 0;">
       <a href="[@trackurl LinkID='' LinkName='spotitshopit' LinkTag='bb-spotitshopit' LinkDesc='' Tracked='ON' Encode='ON' LinkType='REDIRECT']https://www.sephora.com/ca/fr/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: #000000;">
         Dénichez-les. Procurez-les-vous.
@@ -22,11 +22,6 @@ export default function botnavs(section, locale) {
     </td>
   </tr>` : 
   `<tr>
-    <td>
-      <table width="662" height="3" border="0" bgcolor="black" cellspacing="0" cellpadding="0" align="center" style="margin-top:10px;"><td style="font-size:1px; line-height:1px;">&nbsp;</td></table>
-    </td>
-  </tr>
-  <tr>
     <td align="center" style="padding: 10px 0 10px 0;">
     ${locale === 'caEN' ?
       `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/ca/en/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black;">`

--- a/templates/botnavs.js
+++ b/templates/botnavs.js
@@ -9,15 +9,17 @@ export default function botnavs(section, locale) {
     </td>
   </tr>` : ``}
   <tr>
-    <td>
-      <table width="662" height="3" border="0" bgcolor="black" cellspacing="0" cellpadding="0" align="center" style="margin-top:10px;"><td style="font-size:1px; line-height:1px;">&nbsp;</td></table>
+    <td style="padding: 10px 0 0 0;">
+      <table width="662" height="3" border="0" bgcolor="black" cellspacing="0" cellpadding="0" align="center"><td style="font-size:1px; line-height:1px;">&nbsp;</td></table>
     </td>
   </tr>
   ${locale === 'caFR' ?
   `<tr>
     <td align="center" style="padding: 10px 0 10px 0;">
       <a href="[@trackurl LinkID='' LinkName='spotitshopit' LinkTag='bb-spotitshopit' LinkDesc='' Tracked='ON' Encode='ON' LinkType='REDIRECT']https://www.sephora.com/ca/fr/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: #000000;">
-        Dénichez-les. Procurez-les-vous.
+        <strong style="color: #000000; font-weight: normal;"> 
+          Dénichez-les. Procurez-les-vous.
+        </strong>
       </a>
     </td>
   </tr>` : 
@@ -26,7 +28,9 @@ export default function botnavs(section, locale) {
     ${locale === 'caEN' ?
       `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/ca/en/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black;">`
       : `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black;">`}
-        Spot it. Shop it.
+        <strong style="color: #000000; font-weight: normal;">
+          Spot it. Shop it.
+        </strong>
       </a>
     </td>
   </tr>`}

--- a/templates/botnavs.js
+++ b/templates/botnavs.js
@@ -9,18 +9,20 @@ export default function botnavs(section, locale) {
     </td>
   </tr>` : ``}
   ${locale === 'caFR' ?
-  `<tr>
-    <td align="center">
-      <a href="[@trackurl LinkID='' LinkName='spotitshopit' LinkTag='bb-spotitshopit' LinkDesc='' Tracked='ON' Encode='ON' LinkType='REDIRECT']https://www.sephora.com/ca/fr/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; border-top: 3px solid black; padding: 10px 0 10px 0;">
+  `<tr><td></td><td height="3px" width="662px" bgcolor="black"></td><td></td></tr>
+  <tr>
+    <td align="center" colspan="3">
+      <a href="[@trackurl LinkID='' LinkName='spotitshopit' LinkTag='bb-spotitshopit' LinkDesc='' Tracked='ON' Encode='ON' LinkType='REDIRECT']https://www.sephora.com/ca/fr/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; padding: 10px 0 10px 0;">
         Dénichez-les. Procurez-les-vous.
       </a>
     </td>
   </tr>` : 
-  `<tr>
-    <td align="center">
+  `<tr><td></td><td height="3px" width="662px" bgcolor="black"></td><td></td></tr>
+  <tr>
+    <td align="center" colspan="3">
     ${locale === 'caEN' ?
-      `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/ca/en/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; border-top: 3px solid black; padding: 10px 0 10px 0;">`
-      : `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; border-top: 3px solid black; padding: 10px 0 10px 0;">`}
+      `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/ca/en/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; padding: 10px 0 10px 0;">`
+      : `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; padding: 10px 0 10px 0;">`}
         Spot it. Shop it.
       </a>
     </td>

--- a/templates/botnavs.js
+++ b/templates/botnavs.js
@@ -11,17 +11,11 @@ export default function botnavs(section, locale) {
   ${locale === 'caFR' ?
   `<tr>
     <td>
-      <table width="700" border="0" cellspacing="0" cellpadding="0" align="center" style="padding-top: 10px;">
-        <tr>
-          <td height="3" width="19" style="margin: 0; padding: 0; font-size: 1px; mso-line-height-rule: exactly; line-height: 1px"></td>
-          <td height="3" width="662" bgcolor="#000000" style="background-color: #000000; margin: 0; padding: 0; font-size: 1px; mso-line-height-rule: exactly; line-height: 1px;"></td>
-          <td height="3" width="19" style="margin: 0; padding: 0; font-size: 1px; mso-line-height-rule: exactly; line-height: 1px;"></td>
-        </tr>
-      </table>
+      <table width="662" height="3" border="0" bgcolor="black" cellspacing="0" cellpadding="0" align="center" style="margin-top:10px;"><td style="font-size:1px; line-height:1px;">&nbsp;</td></table>
     </td>
   </tr>
   <tr>
-    <td align="center" style="padding: 10 0 10 0;">
+    <td align="center" style="padding: 10px 0 10px 0;">
       <a href="[@trackurl LinkID='' LinkName='spotitshopit' LinkTag='bb-spotitshopit' LinkDesc='' Tracked='ON' Encode='ON' LinkType='REDIRECT']https://www.sephora.com/ca/fr/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: #000000;">
         Dénichez-les. Procurez-les-vous.
       </a>
@@ -29,13 +23,7 @@ export default function botnavs(section, locale) {
   </tr>` : 
   `<tr>
     <td>
-      <table width="700" border="0" cellspacing="0" cellpadding="0" align="center" style="padding-top: 10px;">
-        <tr>
-          <td height="3" width="19" style="margin: 0; padding: 0; font-size: 1px; mso-line-height-rule: exactly; line-height: 1px"></td>
-          <td height="3" width="662" bgcolor="#000000" style="background-color: #000000; margin: 0; padding: 0; font-size: 1px; mso-line-height-rule: exactly; line-height: 1px;"></td>
-          <td height="3" width="19" style="margin: 0; padding: 0; font-size: 1px; mso-line-height-rule: exactly; line-height: 1px;"></td>
-        </tr>
-      </table>
+      <table width="662" height="3" border="0" bgcolor="black" cellspacing="0" cellpadding="0" align="center" style="margin-top:10px;"><td style="font-size:1px; line-height:1px;">&nbsp;</td></table>
     </td>
   </tr>
   <tr>

--- a/templates/botnavs.js
+++ b/templates/botnavs.js
@@ -9,20 +9,40 @@ export default function botnavs(section, locale) {
     </td>
   </tr>` : ``}
   ${locale === 'caFR' ?
-  `<tr><td></td><td height="3px" width="662px" bgcolor="black"></td><td></td></tr>
+  `<tr>
+    <td>
+      <table width="700" border="0" cellspacing="0" cellpadding="0" align="center" style="padding-top: 10px;">
+        <tr>
+          <td height="3" width="19" style="margin: 0; padding: 0; font-size: 1px; mso-line-height-rule: exactly; line-height: 1px"></td>
+          <td height="3" width="662" bgcolor="#000000" style="background-color: #000000; margin: 0; padding: 0; font-size: 1px; mso-line-height-rule: exactly; line-height: 1px;"></td>
+          <td height="3" width="19" style="margin: 0; padding: 0; font-size: 1px; mso-line-height-rule: exactly; line-height: 1px;"></td>
+        </tr>
+      </table>
+    </td>
+  </tr>
   <tr>
-    <td align="center" colspan="3">
-      <a href="[@trackurl LinkID='' LinkName='spotitshopit' LinkTag='bb-spotitshopit' LinkDesc='' Tracked='ON' Encode='ON' LinkType='REDIRECT']https://www.sephora.com/ca/fr/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; padding: 10px 0 10px 0;">
+    <td align="center" style="padding: 10 0 10 0;">
+      <a href="[@trackurl LinkID='' LinkName='spotitshopit' LinkTag='bb-spotitshopit' LinkDesc='' Tracked='ON' Encode='ON' LinkType='REDIRECT']https://www.sephora.com/ca/fr/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: #000000;">
         Dénichez-les. Procurez-les-vous.
       </a>
     </td>
   </tr>` : 
-  `<tr><td></td><td height="3px" width="662px" bgcolor="black"></td><td></td></tr>
+  `<tr>
+    <td>
+      <table width="700" border="0" cellspacing="0" cellpadding="0" align="center" style="padding-top: 10px;">
+        <tr>
+          <td height="3" width="19" style="margin: 0; padding: 0; font-size: 1px; mso-line-height-rule: exactly; line-height: 1px"></td>
+          <td height="3" width="662" bgcolor="#000000" style="background-color: #000000; margin: 0; padding: 0; font-size: 1px; mso-line-height-rule: exactly; line-height: 1px;"></td>
+          <td height="3" width="19" style="margin: 0; padding: 0; font-size: 1px; mso-line-height-rule: exactly; line-height: 1px;"></td>
+        </tr>
+      </table>
+    </td>
+  </tr>
   <tr>
-    <td align="center" colspan="3">
+    <td align="center" style="padding: 10px 0 10px 0;">
     ${locale === 'caEN' ?
-      `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/ca/en/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; padding: 10px 0 10px 0;">`
-      : `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; padding: 10px 0 10px 0;">`}
+      `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/ca/en/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black;">`
+      : `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black;">`}
         Spot it. Shop it.
       </a>
     </td>

--- a/templates/botnavs.js
+++ b/templates/botnavs.js
@@ -11,7 +11,7 @@ export default function botnavs(section, locale) {
   ${locale === 'caFR' ?
   `<tr>
     <td align="center">
-      <a href="[@trackurl LinkID='' LinkName='spotitshopit' LinkTag='bb-spotitshopit' LinkDesc='' Tracked='ON' Encode='ON' LinkType='REDIRECT']https://www.sephora.com/ca/fr/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; border-top: 3px solid black; padding-top: 10px;">
+      <a href="[@trackurl LinkID='' LinkName='spotitshopit' LinkTag='bb-spotitshopit' LinkDesc='' Tracked='ON' Encode='ON' LinkType='REDIRECT']https://www.sephora.com/ca/fr/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; border-top: 3px solid black; padding: 10px 0 10px 0;">
         Dénichez-les. Procurez-les-vous.
       </a>
     </td>
@@ -19,8 +19,8 @@ export default function botnavs(section, locale) {
   `<tr>
     <td align="center">
     ${locale === 'caEN' ?
-      `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/ca/en/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; border-top: 3px solid black; padding-top: 10px;">`
-      : `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; border-top: 3px solid black; padding-top: 10px;">`}
+      `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/ca/en/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; border-top: 3px solid black; padding: 10px 0 10px 0;">`
+      : `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; border-top: 3px solid black; padding: 10px 0 10px 0;">`}
         Spot it. Shop it.
       </a>
     </td>

--- a/templates/botnavs.js
+++ b/templates/botnavs.js
@@ -10,18 +10,18 @@ export default function botnavs(section, locale) {
   </tr>` : ``}
   ${locale === 'caFR' ?
   `<tr>
-    <td>
-      <a href="[@trackurl LinkID='' LinkName='spotitshopit' LinkTag='bb-spotitshopit' LinkDesc='' Tracked='ON' Encode='ON' LinkType='REDIRECT']https://www.sephora.com/ca/fr/?$deep_link=true[/@trackurl]"  target="_blank">
-        <img border="0" style="display: block" alt="Spot it. Shop it." src="https://epidm.epsilon.com/CMS/Coding/Sephora/2018/05_May/01386064/ShotSpop_FR.jpg" width="700" height="71" />
+    <td align="center">
+      <a href="[@trackurl LinkID='' LinkName='spotitshopit' LinkTag='bb-spotitshopit' LinkDesc='' Tracked='ON' Encode='ON' LinkType='REDIRECT']https://www.sephora.com/ca/fr/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; border-top: 3px solid black; padding-top: 10px;">
+        Dénichez-les. Procurez-les-vous.
       </a>
     </td>
   </tr>` : 
   `<tr>
-    <td>
+    <td align="center">
     ${locale === 'caEN' ?
-      `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/ca/en/?$deep_link=true[/@trackurl]"  target="_blank">`
-      : `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/?$deep_link=true[/@trackurl]"  target="_blank">`}
-        <img border="0" style="display: block" alt="Spot it. Shop it." src="http://images.harmony.epsilon.com/ContentHandler/images?id=991bc8b3-0692-4b3a-86b8-1dae13277380" width="700" height="71" />
+      `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/ca/en/?$deep_link=true[/@trackurl]"  target="_blank" style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; border-top: 3px solid black; padding-top: 10px;">`
+      : `<a href="[@trackurl LinkID='db25db80bdb3415d9c857ce10525206e' LinkName='spotitshopit' LinkTag='txt' Tracked='ON' Encode='OFF' AppendSuffix='ON' Render='ON' LinkType='REDIRECT']https://www.sephora.com/?$deep_link=true[/@trackurl]"  target="_blank style="display: block; font-family: Georgia, serif; font-size: 32px; text-decoration: none; color: black; border-top: 3px solid black; padding-top: 10px;">`}
+        Spot it. Shop it.
       </a>
     </td>
   </tr>`}


### PR DESCRIPTION
![{055ECA31-6943-4FD0-9E92-7EBFB23E0E84}](https://user-images.githubusercontent.com/13384164/164061540-e8a8f2b6-39ff-4bfc-82bd-a5d2d069addc.png)

This example taken from Outlook 365 on desktop. the "strong" tag before the text is a lil hack to prevent Outlook from turning the link purple (a:visited) after clicking. Let me know if you have any questions!